### PR TITLE
Add contact save prompt on submit

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,10 +88,10 @@ function initDirectPhoneActions() {
 
   if (btn) {
     btn.addEventListener('click', () => {
-      // Пропонуємо зберегти контакт перед відправкою форми і одразу зберігаємо VCF за згоди користувача.
-      if (window.confirm('Зберегти контакт DOLOTA?')) {
-        const vcf = buildVCard();
-        triggerVcfDownload(vcf);
+      // Перед надсиланням пропонуємо користувачу зберегти контакт.
+      // Якщо погоджується — прапорець збережеться до моменту успішної відправки.
+      const shouldSave = window.confirm('Зберегти контакт DOLOTA після відправлення?');
+      window.__shouldSaveContact = !!shouldSave;
     });
   }
 }
@@ -599,6 +599,7 @@ form.addEventListener('submit', async (e) => {
   const v = validate(fd);
   if (!window.__leadId) window.__leadId = genLeadId();
   if (!v.ok) {
+    window.__shouldSaveContact = false;
     statusEl.textContent = v.msg;
     statusEl.className = 'status err';
     return;


### PR DESCRIPTION
## Summary
- prompt visitors to save the DOLOTA contact when they press "Надіслати"
- persist the user's choice until submission completes successfully and reset it on validation failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d543a39f108328b394a1e3363103fd