### PR TITLE
Handle status response and add gift modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,16 @@
 <button id="saveVCardBtn">Зберегти контакт DOLOTA</button>
 <div class="sub">Натисніть, щоб додати контакт у телефон і повернутися до вибору каталогу.</div>
 </div>
+<div class="modal" id="submissionModal" aria-hidden="true">
+  <div class="modal__backdrop" id="submissionModalBackdrop"></div>
+  <div aria-labelledby="submissionModalTitle" class="modal__content" role="dialog">
+    <button aria-label="Закрити" class="modal__close" id="submissionModalClose" type="button">×</button>
+    <h3 class="modal__title" id="submissionModalTitle">Статус заявки</h3>
+    <p class="modal__description" id="submissionStatusText"></p>
+    <p class="modal__description" id="submissionTelText"></p>
+    <button class="modal__gift-btn" id="claimGiftBtn" type="button">Отримати подарунок</button>
+  </div>
+</div>
 <div class="catalogs" id="catalogs">
 <h3>Каталоги та матеріали</h3>
 <ul>

--- a/script.js
+++ b/script.js
@@ -15,6 +15,14 @@ const statusEl = document.getElementById('status');
 const btn = document.getElementById('submitBtn');
 const catalogs = document.getElementById('catalogs');
 const phoneInput = document.getElementById('phone');
+const submissionModal = document.getElementById('submissionModal');
+const submissionModalBackdrop = document.getElementById('submissionModalBackdrop');
+const submissionModalClose = document.getElementById('submissionModalClose');
+const submissionStatusText = document.getElementById('submissionStatusText');
+const submissionTelText = document.getElementById('submissionTelText');
+const claimGiftBtn = document.getElementById('claimGiftBtn');
+let lastSubmissionStatusValue = null;
+let originalBodyOverflow = '';
 
 const COMPANY_PHONE = '+380933332212';
 const PHONE_PREFIX = '+38';
@@ -51,6 +59,133 @@ async function track(eventName, data) {
   } catch (e) {
     /* noop */
   }
+}
+
+function normalizeStatusData(raw, payload) {
+  const source = raw && typeof raw === 'object' ? raw : {};
+  const statusCandidates = [
+    source.status,
+    source.Status,
+    source.state,
+    source.result && source.result.status,
+    source.data && source.data.status,
+  ];
+  let statusValue = null;
+  for (const cand of statusCandidates) {
+    if ((typeof cand === 'string' || typeof cand === 'number') && String(cand).trim()) {
+      statusValue = String(cand).trim();
+      break;
+    }
+  }
+  if (!statusValue && source && typeof source === 'object') {
+    for (const key of Object.keys(source)) {
+      if (key.toLowerCase().includes('raw')) continue;
+      const value = source[key];
+      if ((typeof value === 'string' || typeof value === 'number') && String(value).trim() && key.toLowerCase().includes('status')) {
+        statusValue = String(value).trim();
+        break;
+      }
+    }
+  }
+  if (!statusValue && source && typeof source === 'object') {
+    for (const [key, value] of Object.entries(source)) {
+      if (key.toLowerCase().includes('raw')) continue;
+      if ((typeof value === 'string' || typeof value === 'number') && String(value).trim()) {
+        statusValue = String(value).trim();
+        break;
+      }
+    }
+  }
+  const telCandidates = [
+    source.tel,
+    source.phone,
+    source.phone_e164,
+    source.phone_digits,
+    payload && payload.phone,
+    payload && payload.phone_e164,
+  ];
+  let telValue = null;
+  for (const cand of telCandidates) {
+    if ((typeof cand === 'string' || typeof cand === 'number') && String(cand).trim()) {
+      telValue = String(cand).trim();
+      break;
+    }
+  }
+  return {
+    raw: source,
+    status: statusValue || null,
+    tel: telValue || null,
+  };
+}
+
+function closeSubmissionModal() {
+  if (!submissionModal) return;
+  submissionModal.classList.remove('is-open');
+  submissionModal.setAttribute('aria-hidden', 'true');
+  if (document.body) {
+    document.body.style.overflow = originalBodyOverflow || '';
+  }
+  lastSubmissionStatusValue = null;
+  if (claimGiftBtn) {
+    claimGiftBtn.disabled = false;
+    claimGiftBtn.textContent = 'Отримати подарунок';
+  }
+}
+
+function openSubmissionModal(data) {
+  if (!submissionModal) return;
+  const statusValue = data && typeof data.status === 'string' ? data.status.trim() : null;
+  const telValue = data && typeof data.tel === 'string' ? data.tel.trim() : null;
+  if (submissionStatusText) {
+    submissionStatusText.textContent = statusValue
+      ? `Статус заявки: ${statusValue}`
+      : 'Статус заявки наразі невідомий. Наш менеджер зв’яжеться з вами найближчим часом.';
+  }
+  if (submissionTelText) {
+    if (telValue) {
+      submissionTelText.textContent = `Телефон: ${telValue}`;
+      submissionTelText.style.display = '';
+    } else {
+      submissionTelText.textContent = '';
+      submissionTelText.style.display = 'none';
+    }
+  }
+  if (claimGiftBtn) {
+    const normalized = statusValue ? statusValue.toLowerCase() : '';
+    const showGift = !['отримано', 'виграв'].includes(normalized);
+    claimGiftBtn.style.display = showGift ? 'inline-flex' : 'none';
+    claimGiftBtn.disabled = false;
+    claimGiftBtn.textContent = 'Отримати подарунок';
+  }
+  submissionModal.classList.add('is-open');
+  submissionModal.setAttribute('aria-hidden', 'false');
+  if (document.body) {
+    originalBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+  lastSubmissionStatusValue = statusValue || null;
+}
+
+if (submissionModalClose) {
+  submissionModalClose.addEventListener('click', closeSubmissionModal);
+}
+if (submissionModalBackdrop) {
+  submissionModalBackdrop.addEventListener('click', closeSubmissionModal);
+}
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && submissionModal && submissionModal.classList.contains('is-open')) {
+    closeSubmissionModal();
+  }
+});
+if (claimGiftBtn) {
+  claimGiftBtn.addEventListener('click', () => {
+    claimGiftBtn.disabled = true;
+    claimGiftBtn.textContent = 'Запит на подарунок відправлено';
+    if (submissionStatusText) {
+      submissionStatusText.textContent = 'Дякуємо! Наш менеджер підготує для вас подарунок.';
+    }
+    track('gift_request_click', { leadId: window.__leadId || null, status: lastSubmissionStatusValue || null });
+  });
 }
 
 // === UTM/Geo helpers ===
@@ -474,15 +609,24 @@ async function sendContactNow(payloadObj) {
     timestamp: new Date().toISOString(),
     event: 'contact_submitted',
   };
+  const response = await fetch(WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    keepalive: true,
+  });
+  if (!response.ok) {
+    throw new Error(`Webhook error ${response.status}`);
+  }
+  const rawText = await response.text();
+  if (!rawText) {
+    return {};
+  }
   try {
-    await fetch(WEBHOOK_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      keepalive: true,
-    });
+    const parsed = JSON.parse(rawText);
+    return parsed && typeof parsed === 'object' ? parsed : { raw: rawText };
   } catch (e) {
-    /* ignore */
+    return { raw: rawText };
   }
 }
 let categorySent = false;
@@ -539,6 +683,7 @@ function loadVisitor() {
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   statusEl.textContent = '';
+  closeSubmissionModal();
   const fd = new FormData(form);
   const v = validate(fd);
   if (!window.__leadId) window.__leadId = genLeadId();
@@ -549,6 +694,8 @@ form.addEventListener('submit', async (e) => {
   }
   btn.disabled = true;
   btn.textContent = 'Запитуємо геолокацію…';
+  statusEl.textContent = 'Готуємо дані…';
+  statusEl.className = 'status';
 
   const payload = Object.fromEntries(fd.entries());
   if (v.phoneCheck) {
@@ -559,7 +706,7 @@ form.addEventListener('submit', async (e) => {
   const meta = await buildUtm(); // тут чекаємо підтвердження/позицію
   const geoPerm = await getGeoPermissionState();
   const tech = await collectTech();
-  const behavior = initBehaviorTracking().snapshot(); // короткий знімок на момент сабміту
+  const behavior = behaviorTracker.snapshot(); // короткий знімок на момент сабміту
   payload.leadId = window.__leadId;
   payload.tag = meta.tag;
   payload.source = 'expo_nfc';
@@ -572,10 +719,17 @@ form.addEventListener('submit', async (e) => {
   payload.geo_permission = geoPerm;
 
   try {
-    await sendContactNow(payload);
-    statusEl.textContent = 'Дякуємо! Дані успішно надіслані.';
+    btn.textContent = 'Відправляємо дані…';
+    statusEl.textContent = 'Відправляємо дані…';
+    const webhookResponse = await sendContactNow(payload);
+    const statusData = normalizeStatusData(webhookResponse, payload);
+    const successMsg = statusData.status
+      ? `Дякуємо! Статус: ${statusData.status}.`
+      : 'Дякуємо! Дані успішно надіслані.';
+    statusEl.textContent = successMsg;
     autoOpenVCard(meta);
     statusEl.className = 'status ok';
+    openSubmissionModal(statusData);
     saveVisitor(payload);
     document.getElementById('afterSubmit').style.display = 'block';
     catalogs.style.display = 'block';

--- a/style.css
+++ b/style.css
@@ -419,3 +419,87 @@ footer {
   background: transparent;
   border: 0;
 }
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.is-open {
+  display: flex;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 3, 2, 0.8);
+  backdrop-filter: blur(3px);
+}
+
+.modal__content {
+  position: relative;
+  background: linear-gradient(180deg, var(--card) 0%, var(--card-2) 100%);
+  border: 1px solid var(--input-border);
+  border-radius: 16px;
+  padding: 24px;
+  width: min(90vw, 420px);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+  text-align: center;
+}
+
+.modal__title {
+  margin: 0 0 12px;
+  font-size: 20px;
+}
+
+.modal__description {
+  margin: 8px 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.modal__close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 0;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--muted);
+  font-size: 20px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.modal__close:hover {
+  filter: brightness(1.1);
+}
+
+.modal__gift-btn {
+  margin-top: 16px;
+  padding: 12px 18px;
+  border: 0;
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--brand-yellow) 0%, #e7b629 100%);
+  color: #2b1d13;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.06s ease, filter 0.2s ease;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.modal__gift-btn:hover {
+  filter: brightness(1.05);
+}
+
+.modal__gift-btn:active {
+  transform: translateY(1px);
+}


### PR DESCRIPTION
## Summary
- wait for the Make webhook response before finalising the submission flow and surface the returned status
- show a modal with the webhook status details and expose a gift request button whenever the status is not "Отримано" or "Виграв"
- style the new modal overlay and gift button so they match the existing design

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d580a7ad4c83288c67da35fe7fbdca