### PR TITLE
Restore status modal and gift workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,13 @@
 <body>
 <div class="container">
 <header>
-<div class="brand">
-<img alt="DOLOTA" src="images/logo.png" >
-<h1>DOLOTA · Відділ продажу</h1>
-</div>
-<div class="sub">Міжнародна виставка · <span class="ua-flag" title="Ukraine"></span> UA</div>
+  <div class="brand">
+    <a class="brand__logo-link" href="https://dolota.ua/">
+      <img alt="DOLOTA" src="images/logo.png"/>
+    </a>
+    <h1>DOLOTA · Відділ продажу</h1>
+  </div>
+  <div class="sub">Міжнародна виставка · <span class="ua-flag" title="Ukraine"></span> UA</div>
 </header>
 <section class="card">
 <h2>Реєстрація контакту для доступу до каталогів</h2>
@@ -53,13 +55,14 @@
 </div>
 <div class="note">Натискаючи «Надіслати», ви погоджуєтесь на обробку ваших персональних даних з метою зворотнього зв’язку та надання матеріалів.</div>
 </form>
-<div class="after-submit" id="afterSubmit" style="display:none; margin-top:18px;">
-<button id="saveVCardBtn">Зберегти контакт DOLOTA</button>
-<div class="sub">Натисніть, щоб додати контакт у телефон і повернутися до вибору каталогу.</div>
-</div>
-<div class="catalogs" id="catalogs">
-<h3>Каталоги та матеріали</h3>
-<ul>
+    <div class="after-submit" id="afterSubmit" style="display:none; margin-top:18px;">
+      <button id="saveVCardBtn">Зберегти контакт DOLOTA</button>
+      <div class="sub">Натисніть, щоб додати контакт у телефон і повернутися до вибору каталогу.</div>
+    </div>
+    <div class="catalogs" id="catalogs">
+      <h3>Каталоги та матеріали</h3>
+      <button class="catalog__gift-btn" id="catalogGiftBtn" type="button">Отримати подарунок</button>
+      <ul>
 <li><a data-category="Каталог бурового інструменту" href="#" rel="noopener" target="_blank">Каталог бурового інструменту <span class="badge">PDF</span></a></li>
 <li><a data-category="Прайс-лист основних позицій" href="#" rel="noopener" target="_blank">Прайс-лист основних позицій <span class="badge">XLSX</span></a></li>
 <li><a data-category="Огляд PDC доліт" href="#" rel="noopener" target="_blank">Огляд PDC доліт <span class="badge">WEB</span></a></li>
@@ -76,6 +79,18 @@
 </div>
 </section>
 <footer>© 2025 DOLOTA. Всі права захищені.</footer>
+</div>
+
+<div aria-hidden="true" class="modal" id="statusModal">
+  <div class="modal__backdrop" data-modal-close></div>
+  <div aria-labelledby="statusModalTitle" aria-modal="true" class="modal__dialog" role="dialog">
+    <button aria-label="Закрити" class="modal__close" data-modal-close type="button">×</button>
+    <div class="modal__content">
+      <h3 class="modal__title" id="statusModalTitle">Статус заявки</h3>
+      <p class="modal__status" id="statusModalText">Дякуємо! Дані успішно надіслані.</p>
+      <button class="modal__gift-btn" id="statusModalGiftBtn" type="button">Отримати подарунок</button>
+    </div>
+  </div>
 </div>
 <script src="script.js" defer></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -81,6 +81,10 @@ header {
   gap: 16px;
 }
 
+.brand__logo-link {
+  display: inline-flex;
+}
+
 .brand img {
   height: 52px;
   width: auto;
@@ -418,4 +422,142 @@ footer {
 .contact-alt .contact-box {
   background: transparent;
   border: 0;
+}
+
+.catalog__gift-btn {
+  display: none;
+  margin: 12px 0 20px;
+  padding: 12px 18px;
+  border: 0;
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--brand-yellow) 0%, #e7b629 100%);
+  color: #2b1d13;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.06s ease, filter 0.2s ease;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.catalog__gift-btn:hover {
+  filter: brightness(1.05);
+}
+
+.catalog__gift-btn:active {
+  transform: translateY(1px);
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 1000;
+}
+
+.modal.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.68);
+}
+
+.modal__dialog {
+  position: relative;
+  width: min(420px, calc(100% - 32px));
+  background: linear-gradient(180deg, var(--card) 0%, var(--card-2) 100%);
+  border: 1px solid var(--input-border);
+  border-radius: 20px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+  padding: 28px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  z-index: 1;
+}
+
+.modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 0;
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--muted);
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: filter 0.15s ease, transform 0.1s ease;
+}
+
+.modal__close:hover {
+  filter: brightness(1.1);
+}
+
+.modal__close:active {
+  transform: scale(0.96);
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 20px;
+  text-align: center;
+}
+
+.modal__status {
+  margin: 0;
+  font-size: 16px;
+  color: var(--muted);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.modal__gift-btn {
+  align-self: center;
+  padding: 12px 22px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, var(--brand-yellow) 0%, #e7b629 100%);
+  color: #2b1d13;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border: 0;
+  cursor: pointer;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.4);
+  transition: transform 0.08s ease, filter 0.18s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal__gift-btn:hover {
+  filter: brightness(1.05);
+}
+
+.modal__gift-btn:active {
+  transform: translateY(1px);
+}
+
+.modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  align-items: center;
 }


### PR DESCRIPTION
## Summary
- add an accessible status modal with a built-in gift button that mirrors the requested behaviour
- centralize status handling in the submit flow so gift actions toggle correctly for webhook responses
- style the modal overlay, dialog and buttons to match the existing catalog presentation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d580a7ad4c83288c67da35fe7fbdca