### PR TITLE
Handle webhook status response and add gift link

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,12 @@
 <body>
 <div class="container">
 <header>
-<div class="brand">
-<img alt="DOLOTA" src="images/logo.png" >
-<h1>DOLOTA · Відділ продажу</h1>
-</div>
+    <div class="brand">
+      <a href="https://dolota.ua/" target="_blank" rel="noopener">
+        <img alt="DOLOTA" src="images/logo.png" />
+      </a>
+      <h1>DOLOTA · Відділ продажу</h1>
+    </div>
 <div class="sub">Міжнародна виставка · <span class="ua-flag" title="Ukraine"></span> UA</div>
 </header>
 <section class="card">

--- a/style.css
+++ b/style.css
@@ -81,6 +81,11 @@ header {
   gap: 16px;
 }
 
+.brand a {
+  display: inline-flex;
+  align-items: center;
+}
+
 .brand img {
   height: 52px;
   width: auto;
@@ -279,6 +284,29 @@ button:active {
   border: 1px solid var(--input-border);
   text-decoration: none;
   color: var(--text);
+}
+
+.gift-btn {
+  display: inline-block;
+  margin-top: 18px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--brand-primary) 0%, #8a5a2c 100%);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  transition: transform 0.06s ease, filter 0.2s ease;
+  text-align: center;
+}
+
+.gift-btn:hover {
+  filter: brightness(1.08);
+}
+
+.gift-btn:active {
+  transform: translateY(1px);
 }
 
 .badge {


### PR DESCRIPTION
## Summary
- wrap the DOLOTA logo in a link to the public site
- wait for the webhook response, extract the returned status and render a gift CTA when it equals “Не брав участі”
- add styling for the new CTA button so it matches existing buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d59bda483483288c634f115c3460c3