### PR TITLE
Add phone confirmation and fortune wheel pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
 <title>DOLOTA | Реєстрація контакту</title>
 <meta content="Реєстрація контакту відвідувача стенду DOLOTA для надання доступу до каталогів." name="description"/>
-<link href="style.css" rel="stylesheet"/>
+<link href="styles/index.css" rel="stylesheet"/>
 </head>
 <body>
 <div class="container">
@@ -79,6 +79,6 @@
 </section>
 <footer>© 2025 DOLOTA. Всі права захищені.</footer>
 </div>
-<script src="script.js" defer></script>
+<script src="scripts/main.js" defer></script>
 </body>
 </html>

--- a/pages/phone-confirmation.html
+++ b/pages/phone-confirmation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DOLOTA | Підтвердження телефону</title>
+    <link rel="stylesheet" href="../styles/index.css" />
+    <link rel="stylesheet" href="../styles/phone-confirmation.css" />
+  </head>
+  <body>
+    <div class="container confirmation-container">
+      <header>
+        <div class="brand">
+          <a href="https://dolota.ua/" target="_blank" rel="noopener">
+            <img src="../images/logo.png" alt="DOLOTA" />
+          </a>
+          <h1>DOLOTA · Підтвердження телефону</h1>
+        </div>
+        <div class="sub">Міжнародна виставка · <span class="ua-flag" title="Ukraine"></span> UA</div>
+      </header>
+      <section class="card">
+        <h2>Підтвердження номера телефону</h2>
+        <p class="sub">
+          Щоб отримати доступ до розіграшу подарунків, підтвердіть свій номер телефону. Ми надішлемо SMS через платформу
+          <strong>SMS-fly</strong> з кодом підтвердження.
+        </p>
+        <form id="smsConfirmForm" novalidate>
+          <div class="confirmation-block">
+            <label for="phoneDisplay">Ваш номер</label>
+            <input id="phoneDisplay" name="phoneDisplay" readonly />
+            <small class="sub">Номер передано з реєстраційної форми та його не можна змінити.</small>
+          </div>
+          <div class="confirmation-actions">
+            <button type="button" id="sendSmsBtn">Надіслати SMS з кодом</button>
+            <span class="status" id="status"></span>
+          </div>
+          <div class="code-entry" id="codeEntry" hidden>
+            <label class="req" for="codeInput">Код підтвердження</label>
+            <input id="codeInput" name="code" inputmode="numeric" maxlength="6" placeholder="Введіть код" required />
+            <button type="submit" id="confirmBtn" disabled>Підтвердити номер</button>
+          </div>
+        </form>
+        <div class="back-link">
+          <a href="../index.html">← Повернутися до форми</a>
+        </div>
+      </section>
+      <footer>© 2025 DOLOTA. Всі права захищені.</footer>
+    </div>
+    <script src="../scripts/phone-confirmation.js" defer></script>
+  </body>
+</html>

--- a/pages/wheel.html
+++ b/pages/wheel.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="uk">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DOLOTA | Колесо фортуни</title>
+    <link rel="stylesheet" href="../styles/index.css" />
+    <link rel="stylesheet" href="../styles/wheel.css" />
+  </head>
+  <body>
+    <div class="container wheel-container">
+      <header>
+        <div class="brand">
+          <a href="https://dolota.ua/" target="_blank" rel="noopener">
+            <img src="../images/logo.png" alt="DOLOTA" />
+          </a>
+          <h1>DOLOTA · Колесо фортуни</h1>
+        </div>
+        <div class="sub">Міжнародна виставка · <span class="ua-flag" title="Ukraine"></span> UA</div>
+      </header>
+      <section class="card wheel-card">
+        <h2>Розіграш подарунків</h2>
+        <p class="sub">
+          Обертайте колесо фортуни, щоб виграти один із п’яти призів. Кожен підтверджений номер може обертати колесо лише один раз.
+        </p>
+        <div class="wheel-wrapper">
+          <div class="wheel" id="wheel"></div>
+          <div class="pointer"></div>
+        </div>
+        <div class="wheel-actions">
+          <button id="spinBtn">Запустити колесо</button>
+          <span class="status" id="wheelStatus"></span>
+        </div>
+        <div class="result" id="result" aria-live="polite"></div>
+        <div class="back-link">
+          <a href="../index.html">← На головну</a>
+        </div>
+      </section>
+      <footer>© 2025 DOLOTA. Всі права захищені.</footer>
+    </div>
+
+    <div class="modal" id="prizeModal" hidden>
+      <div class="modal-content">
+        <h3>Вітаємо!</h3>
+        <p id="modalText">Ви виграли подарунок.</p>
+        <a class="modal-btn" id="claimBtn" target="_blank" rel="noopener">Отримати виграш</a>
+        <button class="modal-close" id="closeModal" type="button">Закрити</button>
+      </div>
+    </div>
+
+    <script src="../scripts/wheel.js" defer></script>
+  </body>
+</html>

--- a/scripts/phone-confirmation.js
+++ b/scripts/phone-confirmation.js
@@ -1,0 +1,128 @@
+const SMS_FLY_WEBHOOK = 'https://hook.eu2.make.com/0wYXQJWU5CzJpaKeHG4PkbwBh3kl9cs4';
+const PHONE_PREFIX = '+38';
+
+const form = document.getElementById('smsConfirmForm');
+const phoneDisplay = document.getElementById('phoneDisplay');
+const sendSmsBtn = document.getElementById('sendSmsBtn');
+const statusEl = document.getElementById('status');
+const codeEntry = document.getElementById('codeEntry');
+const codeInput = document.getElementById('codeInput');
+const confirmBtn = document.getElementById('confirmBtn');
+
+function formatPhone(digits) {
+  if (!digits) return '';
+  const cleaned = String(digits).replace(/\D/g, '').slice(-10);
+  return `${PHONE_PREFIX} ${cleaned.replace(/(\d{3})(\d{3})(\d{2})(\d{2})/, '$1 $2 $3 $4')}`.trim();
+}
+
+function parseParams() {
+  const params = new URLSearchParams(location.search);
+  const phone = params.get('phone') || '';
+  const leadId = params.get('leadId') || '';
+  const token = params.get('token') || '';
+  const expected = phone && leadId ? btoa(`${phone}:${leadId}`) : '';
+  if (!phone || !leadId || !token || token !== expected) {
+    throw new Error('Передано некоректні дані.');
+  }
+  return { phone, leadId, token };
+}
+
+let ctx;
+try {
+  ctx = parseParams();
+  phoneDisplay.value = formatPhone(ctx.phone);
+} catch (err) {
+  if (statusEl) {
+    statusEl.textContent = err.message;
+    statusEl.className = 'status err';
+  }
+  if (sendSmsBtn) sendSmsBtn.disabled = true;
+  if (confirmBtn) confirmBtn.disabled = true;
+}
+
+function setStatus(msg, type = '') {
+  if (!statusEl) return;
+  statusEl.textContent = msg || '';
+  statusEl.className = type ? `status ${type}` : 'status';
+}
+
+async function postToWebhook(eventName, extra) {
+  if (!ctx) throw new Error('Контекст не ініціалізовано.');
+  const payload = {
+    event: eventName,
+    leadId: ctx.leadId,
+    phone: `${PHONE_PREFIX}${ctx.phone}`,
+    token: ctx.token,
+    ...extra,
+  };
+  const response = await fetch(SMS_FLY_WEBHOOK, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`Помилка запиту: ${response.status}`);
+  }
+  return response.json().catch(() => null);
+}
+
+let smsSent = false;
+if (sendSmsBtn && ctx) {
+  sendSmsBtn.addEventListener('click', async () => {
+    if (smsSent) return;
+    try {
+      sendSmsBtn.disabled = true;
+      setStatus('Відправляємо SMS…', '');
+      await postToWebhook('sms_code_requested');
+      smsSent = true;
+      setStatus('SMS успішно відправлено. Введіть код з повідомлення.', 'ok');
+      codeEntry.hidden = false;
+      confirmBtn.disabled = false;
+      codeInput.focus();
+    } catch (err) {
+      sendSmsBtn.disabled = false;
+      setStatus(err.message || 'Не вдалося надіслати SMS. Спробуйте пізніше.', 'err');
+    }
+  });
+}
+
+if (form && ctx) {
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    if (!smsSent) {
+      setStatus('Спершу надішліть SMS з кодом.', 'err');
+      return;
+    }
+    const code = (codeInput.value || '').trim();
+    if (code.length < 3) {
+      setStatus('Код має містити щонайменше 3 цифри.', 'err');
+      return;
+    }
+    try {
+      confirmBtn.disabled = true;
+      setStatus('Перевіряємо код…', '');
+      await postToWebhook('sms_code_confirmed', { code });
+      setStatus('Номер успішно підтверджено! Перехід до розіграшу…', 'ok');
+      sessionStorage.setItem(
+        'dolota_wheel_access',
+        JSON.stringify({ leadId: ctx.leadId, phone: ctx.phone, token: ctx.token, ts: Date.now() }),
+      );
+      const wheelUrl = new URL('wheel.html', location.href);
+      wheelUrl.searchParams.set('leadId', ctx.leadId);
+      wheelUrl.searchParams.set('phone', ctx.phone);
+      wheelUrl.searchParams.set('token', ctx.token);
+      setTimeout(() => {
+        location.href = wheelUrl.toString();
+      }, 600);
+    } catch (err) {
+      confirmBtn.disabled = false;
+      setStatus(err.message || 'Код не підтверджено. Спробуйте ще раз.', 'err');
+    }
+  });
+}
+
+if (codeInput) {
+  codeInput.addEventListener('input', () => {
+    codeInput.value = codeInput.value.replace(/\D/g, '').slice(0, 6);
+  });
+}

--- a/scripts/wheel.js
+++ b/scripts/wheel.js
@@ -1,0 +1,177 @@
+const GIFTS = [
+  { label: 'Знижка 10% на обладнання', color: '#ff7a18' },
+  { label: 'Фірмовий худі DOLOTA', color: '#fbd786' },
+  { label: 'Сертифікат на сервіс', color: '#c6ffdd' },
+  { label: 'Набір сувенірів', color: '#6dd5fa' },
+  { label: 'Безкоштовна доставка', color: '#f7797d' },
+];
+
+const WHEEL_WEBHOOK = 'https://hook.eu2.make.com/tru0i39wnyegjkfjkw2ae1xs5wt9mnne';
+const TELEGRAM_BOT_URL = 'https://t.me/dolota_pr_bot';
+
+const wheelEl = document.getElementById('wheel');
+const spinBtn = document.getElementById('spinBtn');
+const statusEl = document.getElementById('wheelStatus');
+const resultEl = document.getElementById('result');
+const modal = document.getElementById('prizeModal');
+const modalText = document.getElementById('modalText');
+const claimBtn = document.getElementById('claimBtn');
+const closeModalBtn = document.getElementById('closeModal');
+
+function parseParams() {
+  const params = new URLSearchParams(location.search);
+  const phone = params.get('phone') || '';
+  const leadId = params.get('leadId') || '';
+  const token = params.get('token') || '';
+  const expected = phone && leadId ? btoa(`${phone}:${leadId}`) : '';
+  if (!phone || !leadId || !token || token !== expected) {
+    throw new Error('Відсутні дані для участі у розіграші.');
+  }
+  return { phone, leadId, token };
+}
+
+function restoreAccess() {
+  try {
+    const raw = sessionStorage.getItem('dolota_wheel_access');
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || !parsed.phone || !parsed.leadId) return null;
+    return parsed;
+  } catch (e) {
+    return null;
+  }
+}
+
+function setStatus(message, type = '') {
+  if (!statusEl) return;
+  statusEl.textContent = message || '';
+  statusEl.className = type ? `status ${type}` : 'status';
+}
+
+let ctx;
+try {
+  ctx = parseParams();
+  const access = restoreAccess();
+  if (!access || access.phone !== ctx.phone || access.leadId !== ctx.leadId) {
+    throw new Error('Не знайдено підтвердження номера телефону.');
+  }
+} catch (err) {
+  setStatus(err.message, 'err');
+  if (spinBtn) spinBtn.disabled = true;
+}
+
+function buildWheelSegments() {
+  if (!wheelEl) return;
+  const segmentAngle = 360 / GIFTS.length;
+  let gradientStops = '';
+  GIFTS.forEach((gift, index) => {
+    const start = index * segmentAngle;
+    const end = start + segmentAngle;
+    gradientStops += `${gift.color} ${start}deg ${end}deg`;
+    if (index !== GIFTS.length - 1) gradientStops += ', ';
+  });
+  wheelEl.style.background = `conic-gradient(${gradientStops})`;
+}
+
+buildWheelSegments();
+
+let isSpinning = false;
+let currentRotation = 0;
+
+function getSpinKey() {
+  if (!ctx) return null;
+  return `dolota_wheel_spin_${ctx.phone}`;
+}
+
+function hasSpunBefore() {
+  const key = getSpinKey();
+  if (!key) return false;
+  try {
+    return Boolean(localStorage.getItem(key));
+  } catch (e) {
+    return false;
+  }
+}
+
+function markSpin(prize) {
+  const key = getSpinKey();
+  if (!key) return;
+  try {
+    localStorage.setItem(key, JSON.stringify({ prize, ts: Date.now(), leadId: ctx.leadId }));
+  } catch (e) {
+    /* ignore */
+  }
+}
+
+async function sendPrize(prize) {
+  if (!ctx) return;
+  try {
+    await fetch(WHEEL_WEBHOOK, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: 'wheel_spin',
+        leadId: ctx.leadId,
+        phone: `+38${ctx.phone}`,
+        prize,
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch (e) {
+    /* noop */
+  }
+}
+
+function openModal(prize) {
+  if (!modal || !modalText || !claimBtn) return;
+  modalText.textContent = `Ваш приз: ${prize}. Натисніть, щоб забрати його у чат-боті.`;
+  claimBtn.href = `${TELEGRAM_BOT_URL}?start=${encodeURIComponent(ctx.leadId)}`;
+  modal.hidden = false;
+}
+
+if (closeModalBtn) {
+  closeModalBtn.addEventListener('click', () => {
+    modal.hidden = true;
+  });
+}
+
+function spinWheel() {
+  if (!ctx) {
+    setStatus('Дані доступу відсутні.', 'err');
+    return;
+  }
+  if (hasSpunBefore()) {
+    setStatus('Цей номер вже брав участь у розіграші.', 'err');
+    return;
+  }
+  if (isSpinning) return;
+  isSpinning = true;
+  setStatus('Колесо обертається…');
+  const segmentAngle = 360 / GIFTS.length;
+  const selectedIndex = Math.floor(Math.random() * GIFTS.length);
+  const targetAngle = 360 - (selectedIndex * segmentAngle + segmentAngle / 2);
+  const spins = 5;
+  currentRotation = spins * 360 + targetAngle;
+  wheelEl.style.transform = `rotate(${currentRotation}deg)`;
+
+  const onTransitionEnd = () => {
+    wheelEl.removeEventListener('transitionend', onTransitionEnd);
+    const prize = GIFTS[selectedIndex].label;
+    setStatus('Вітаємо! Ви виграли приз.', 'ok');
+    resultEl.textContent = `Ваш приз: ${prize}`;
+    markSpin(prize);
+    sendPrize(prize);
+    if (spinBtn) spinBtn.disabled = true;
+    setTimeout(() => openModal(prize), 3000);
+  };
+
+  wheelEl.addEventListener('transitionend', onTransitionEnd, { once: true });
+}
+
+if (spinBtn) {
+  spinBtn.addEventListener('click', spinWheel);
+  if (hasSpunBefore()) {
+    spinBtn.disabled = true;
+    setStatus('Цей номер вже брав участь у розіграші.', 'err');
+  }
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -2,6 +2,7 @@
   --brand-primary: #8a5a2c;
   --brand-blue: #3a7bd5;
   --brand-yellow: #ffd200;
+  --accent: #ffd200;
   --bg: #111;
   --card: #1a120b;
   --card-2: #24170e;

--- a/styles/phone-confirmation.css
+++ b/styles/phone-confirmation.css
@@ -1,0 +1,61 @@
+.card {
+  max-width: 560px;
+}
+
+.confirmation-container .card {
+  text-align: left;
+}
+
+.confirmation-block input[readonly] {
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  cursor: not-allowed;
+}
+
+.confirmation-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.confirmation-actions .status {
+  flex: 1;
+}
+
+.code-entry {
+  margin-top: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.code-entry[hidden] {
+  display: none;
+}
+
+.code-entry input {
+  font-size: 1.2rem;
+  letter-spacing: 0.2rem;
+  text-align: center;
+}
+
+#confirmBtn[disabled],
+#sendSmsBtn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.back-link {
+  margin-top: 24px;
+  text-align: center;
+}
+
+.back-link a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.back-link a:hover {
+  text-decoration: underline;
+}

--- a/styles/wheel.css
+++ b/styles/wheel.css
@@ -1,0 +1,127 @@
+.wheel-card {
+  max-width: 720px;
+  text-align: center;
+}
+
+.wheel-wrapper {
+  position: relative;
+  width: 320px;
+  height: 320px;
+  margin: 32px auto;
+}
+
+.wheel {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(
+    #ff7a18 0deg 72deg,
+    #fbd786 72deg 144deg,
+    #c6ffdd 144deg 216deg,
+    #6dd5fa 216deg 288deg,
+    #f7797d 288deg 360deg
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #111;
+  font-weight: 700;
+  transition: transform 5s cubic-bezier(0.25, 0.1, 0.1, 1);
+  position: relative;
+}
+
+.wheel::after {
+  content: '';
+  position: absolute;
+  width: 40%;
+  height: 40%;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 50%;
+}
+
+.pointer {
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 16px solid transparent;
+  border-right: 16px solid transparent;
+  border-bottom: 24px solid var(--accent);
+}
+
+.wheel-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+}
+
+#wheelStatus {
+  min-height: 24px;
+}
+
+.result {
+  margin-top: 16px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-content {
+  background: #1f2937;
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 360px;
+  text-align: center;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+}
+
+.modal-content h3 {
+  margin-bottom: 12px;
+}
+
+.modal-btn {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 12px 24px;
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 700;
+  border-radius: 999px;
+  text-decoration: none;
+}
+
+.modal-btn:hover {
+  opacity: 0.9;
+}
+
+.modal-close {
+  margin-top: 20px;
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 8px 16px;
+  border-radius: 999px;
+}
+
+@media (max-width: 540px) {
+  .wheel-wrapper {
+    width: 260px;
+    height: 260px;
+  }
+}


### PR DESCRIPTION
## Summary
- reorganize static assets into dedicated `styles/` and `scripts/` folders
- add an SMS-fly powered phone confirmation page that locks the submitted number
- build a fortune wheel prize page that reports spins via webhook and links to the Telegram bot

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d6ab8082b483289bbeb14eacad9301