### PR TITLE
Persist gift confirmation context across tabs

### DIFF
--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -17,14 +17,55 @@ const statusEl = document.getElementById('confirmStatus');
 
 let context = null;
 
-function parseContext() {
+function clearStoredContext() {
   try {
-    const raw = sessionStorage.getItem(CONTEXT_KEY);
-    if (!raw) return null;
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(CONTEXT_KEY);
+    }
+  } catch (err) {
+    /* noop */
+  }
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.removeItem(CONTEXT_KEY);
+    }
+  } catch (err) {
+    /* noop */
+  }
+}
+
+function parseContext() {
+  let raw = null;
+  try {
+    if (typeof localStorage !== 'undefined') {
+      raw = localStorage.getItem(CONTEXT_KEY);
+    }
+  } catch (err) {
+    raw = null;
+  }
+
+  if (!raw) {
+    try {
+      if (typeof sessionStorage !== 'undefined') {
+        raw = sessionStorage.getItem(CONTEXT_KEY);
+      }
+    } catch (err) {
+      raw = null;
+    }
+  }
+
+  if (!raw) return null;
+
+  try {
     const data = JSON.parse(raw);
-    if (!data || typeof data !== 'object') return null;
+    if (!data || typeof data !== 'object') {
+      clearStoredContext();
+      return null;
+    }
+    clearStoredContext();
     return data;
   } catch (err) {
+    clearStoredContext();
     return null;
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -31,6 +31,37 @@ const PHONE_DIGITS_REQUIRED = 10;
 
 let currentGiftContext = null;
 
+function persistGiftContext(payload) {
+  if (!payload) return;
+  const serialized = JSON.stringify(payload);
+  let stored = false;
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(GIFT_STORAGE_KEY, serialized);
+      stored = true;
+    }
+  } catch (err) {
+    /* noop */
+  }
+  if (stored) {
+    try {
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.removeItem(GIFT_STORAGE_KEY);
+      }
+    } catch (err) {
+      /* noop */
+    }
+    return;
+  }
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem(GIFT_STORAGE_KEY, serialized);
+    }
+  } catch (err) {
+    /* noop */
+  }
+}
+
 function sanitizePhoneDigits(raw = '') {
   return String(raw)
     .replace(/\D/g, '')
@@ -447,7 +478,7 @@ function updateGiftButton(statusValue) {
             phoneDisplay: display || null,
             telegramLink,
           };
-          sessionStorage.setItem(GIFT_STORAGE_KEY, JSON.stringify(contextPayload));
+          persistGiftContext(contextPayload);
         } catch (err) {
           /* noop */
         }


### PR DESCRIPTION
## Summary
- persist the gift lead/phone context in localStorage so it survives opening the confirmation page in a new tab
- adjust the confirmation page to read the context from localStorage or sessionStorage and clear it after use to avoid stale data

## Testing
- Not run (manual verification required)

------
https://chatgpt.com/codex/tasks/task_e_68d827b032a88328afe81beed50ee3dc