### PR TITLE
Fix catalog landing redirect for subdirectory deployments

### DIFF
--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -153,10 +153,19 @@ function contextMatchesVerification(ctx, verification) {
   return true;
 }
 
+function resolveCatalogLandingUrl() {
+  try {
+    const base = (typeof document !== 'undefined' && document.baseURI) ? document.baseURI : location.href;
+    return new URL('catalogs.html', base).toString();
+  } catch (err) {
+    return 'catalogs.html';
+  }
+}
+
 function openCatalogTarget(ctx) {
   if (!ctx || !ctx.catalogUrl) return;
   const url = ctx.catalogUrl;
-  const landingUrl = ctx.landingUrl || '/pages/catalogs.html';
+  const landingUrl = ctx.landingUrl || resolveCatalogLandingUrl();
   let opened = false;
   try {
     const win = window.open(url, '_blank', 'noopener');

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -35,8 +35,8 @@ let catalogsHandlerAttached = false;
 
 function resolveLandingUrl() {
   try {
-    const origin = location && location.origin ? location.origin : new URL(location.href).origin;
-    return new URL(CATALOG_LANDING_PAGE, origin + '/').toString();
+    const base = (typeof document !== 'undefined' && document.baseURI) ? document.baseURI : location.href;
+    return new URL(CATALOG_LANDING_PAGE, base).toString();
   } catch (err) {
     return CATALOG_LANDING_PAGE;
   }


### PR DESCRIPTION
## Summary
- update the catalog landing URL resolver to respect the document base path
- adjust the confirmation page fallback to compute the catalogs URL relative to its location

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd586f4e78832897a5f0fc333f9cb3