### PR TITLE
Handle catalog popup opening without false failures

### DIFF
--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -153,14 +153,28 @@ function contextMatchesVerification(ctx, verification) {
   return true;
 }
 
+function resolveCatalogLandingUrl() {
+  try {
+    const base = (typeof document !== 'undefined' && document.baseURI) ? document.baseURI : location.href;
+    return new URL('catalogs.html', base).toString();
+  } catch (err) {
+    return 'catalogs.html';
+  }
+}
+
 function openCatalogTarget(ctx) {
   if (!ctx || !ctx.catalogUrl) return;
   const url = ctx.catalogUrl;
-  const landingUrl = ctx.landingUrl || '/pages/catalogs.html';
+  const landingUrl = ctx.landingUrl || resolveCatalogLandingUrl();
   let opened = false;
   try {
-    const win = window.open(url, '_blank', 'noopener');
-    opened = !!win;
+    const win = window.open(url, '_blank');
+    if (win) {
+      try {
+        win.opener = null;
+      } catch (e) {}
+      opened = true;
+    }
   } catch (err) {
     opened = false;
   }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -35,8 +35,8 @@ let catalogsHandlerAttached = false;
 
 function resolveLandingUrl() {
   try {
-    const origin = location && location.origin ? location.origin : new URL(location.href).origin;
-    return new URL(CATALOG_LANDING_PAGE, origin + '/').toString();
+    const base = (typeof document !== 'undefined' && document.baseURI) ? document.baseURI : location.href;
+    return new URL(CATALOG_LANDING_PAGE, base).toString();
   } catch (err) {
     return CATALOG_LANDING_PAGE;
   }
@@ -74,10 +74,14 @@ function maybeOpenPendingCatalog() {
   if (!pending) return;
   setTimeout(() => {
     try {
-      const win = window.open(pending, '_blank', 'noopener');
-      if (!win) {
-        window.location.href = pending;
+      const win = window.open(pending, '_blank');
+      if (win) {
+        try {
+          win.opener = null;
+        } catch (e) {}
+        return;
       }
+      window.location.href = pending;
     } catch (err) {
       window.location.href = pending;
     }
@@ -283,8 +287,13 @@ function openCatalogAfterVerification({ url, landingUrl }) {
   if (!url) return;
   let opened = false;
   try {
-    const win = window.open(url, '_blank', 'noopener');
-    opened = !!win;
+    const win = window.open(url, '_blank');
+    if (win) {
+      try {
+        win.opener = null;
+      } catch (e) {}
+      opened = true;
+    }
   } catch (err) {
     opened = false;
   }


### PR DESCRIPTION
## Summary
- update catalog-opening helpers to drop the noopener feature flag and manually clear window.opener
- ensure fallback redirects only trigger when the popup was truly blocked

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd586f4e78832897a5f0fc333f9cb3