### PR TITLE
Require verification before catalog access

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -185,6 +185,52 @@ function hydrateContextFromStorage() {
 
 hydrateContextFromStorage();
 
+function enforceCatalogAccess() {
+  if (!isOnCatalogLandingPage()) return;
+
+  const redirectToIndex = () => {
+    let target = '../index.html';
+    try {
+      target = new URL('../index.html', location.href).toString();
+    } catch (err) {}
+    try {
+      window.location.replace(target);
+    } catch (err) {
+      window.location.href = target;
+    }
+  };
+
+  const context = loadStoredCatalogContext();
+  const verification = getStoredVerification();
+  const digits = context ? sanitizePhoneDigits(context.phoneDigits || context.phone_digits || '') : '';
+
+  if (!digits || digits.length !== PHONE_DIGITS_REQUIRED) {
+    redirectToIndex();
+    return;
+  }
+
+  const normalizedContext = {
+    ...(context && typeof context === 'object' ? context : {}),
+    leadId: (context && (context.leadId || context.lead_id)) || window.__leadId || null,
+    phoneDigits: digits,
+    phoneDisplay:
+      (context && (context.phoneDisplay || context.phone_display)) ||
+      (digits ? `${PHONE_PREFIX}${digits}` : null),
+  };
+
+  currentVerificationContext = normalizedContext;
+  if (!window.__leadId && normalizedContext.leadId) {
+    window.__leadId = normalizedContext.leadId;
+  }
+
+  if (!verification || !isVerificationValidForCurrentContact(verification)) {
+    redirectToIndex();
+    return;
+  }
+}
+
+enforceCatalogAccess();
+
 function updateVerificationContext(payload = {}) {
   try {
     const digits = payload.phone_digits || sanitizePhoneDigits(payload.phone || (phoneInput && phoneInput.value) || '');
@@ -413,75 +459,6 @@ function handleCatalogClick(ev) {
     phoneDisplay,
   };
   window.__leadId = leadId;
-  track('catalog_open', { leadId, category: name, href: url });
-  if (lastSubmitPayload) {
-    sendCategoryUpdate(lastSubmitPayload, name);
-  }
-  const landingUrl = resolveLandingUrl();
-  const contextPayload = {
-    ...currentVerificationContext,
-    catalogName: name,
-    catalogUrl: url,
-    landingUrl,
-  };
-  persistCatalogContext(contextPayload);
-  const verification = getStoredVerification();
-  if (verification && isVerificationValidForCurrentContact(verification)) {
-    openCatalogAfterVerification({ url, landingUrl });
-    return;
-  }
-  redirectToConfirm(contextPayload);
-}
-
-function ensureCatalogHandler() {
-  if (!catalogs || catalogsHandlerAttached) return;
-  if (isOnCatalogLandingPage()) return;
-  catalogs.addEventListener('click', handleCatalogClick);
-  catalogsHandlerAttached = true;
-}
-
-function handleCatalogClick(ev) {
-  const a = ev.target.closest('#catalogs a[data-category], #catalogs a[href], #catalogs a[data-url]');
-  if (!a) return;
-  ev.preventDefault();
-  const rawHref = a.getAttribute('href');
-  const dataUrl = a.getAttribute('data-url') || a.dataset.url;
-  const hasDirectHref = rawHref && rawHref !== '#';
-  const baseHref = hasDirectHref ? rawHref : dataUrl;
-  if (!baseHref) {
-    promptForMissingContext();
-    return;
-  }
-  const name = a.getAttribute('data-category') || a.textContent.trim();
-  let url;
-  if (hasDirectHref) {
-    url = a.href;
-  } else {
-    try {
-      url = new URL(baseHref, location.href).toString();
-    } catch (err) {
-      url = baseHref;
-    }
-  }
-  window.__selectedCategory = name;
-  const ctx = ensureVerificationContextFromForm();
-  const phoneDigits = ctx && ctx.phoneDigits;
-  const leadId = window.__leadId || (ctx && ctx.leadId) || null;
-  if (!leadId || !phoneDigits || phoneDigits.length !== PHONE_DIGITS_REQUIRED) {
-    promptForMissingContext();
-    return;
-  }
-  const phoneDisplay = ctx && ctx.phoneDisplay ? ctx.phoneDisplay : `${PHONE_PREFIX}${phoneDigits}`;
-  currentVerificationContext = {
-    leadId,
-    phoneDigits,
-    phoneDisplay,
-  };
-  window.__leadId = leadId;
-  track('catalog_open', { leadId, category: name, href: url });
-  if (lastSubmitPayload) {
-    sendCategoryUpdate(lastSubmitPayload, name);
-  }
   const landingUrl = resolveLandingUrl();
   const contextPayload = {
     ...currentVerificationContext,
@@ -990,31 +967,6 @@ async function sendContactNow(payloadObj) {
   }
   return data;
 }
-let categorySent = false;
-async function sendCategoryUpdate(payloadObj, category) {
-  if (categorySent) return;
-  categorySent = true;
-  const params = new URLSearchParams(location.search);
-  const tag = params.get('tag') || 'nfc_unknown';
-  const body = {
-    ...payloadObj,
-    tag,
-    source: 'expo_nfc',
-    timestamp: new Date().toISOString(),
-    event: 'category_selected',
-    category: category || null,
-  };
-  try {
-    await fetch(WEBHOOK_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      keepalive: true,
-    });
-  } catch (e) {
-    /* ignore */
-  }
-}
 
 // === Збереження контакту локально ===
 function saveVisitor(payload) {
@@ -1157,7 +1109,10 @@ function updateOnlineStatus() {
 window.addEventListener('online', updateOnlineStatus);
 window.addEventListener('offline', updateOnlineStatus);
 document.addEventListener('DOMContentLoaded', updateOnlineStatus);
-document.addEventListener('DOMContentLoaded', maybeOpenPendingCatalog);
+document.addEventListener('DOMContentLoaded', () => {
+  enforceCatalogAccess();
+  maybeOpenPendingCatalog();
+});
 
 (function initCallCta() {
   const callBtn = document.getElementById('callCta');


### PR DESCRIPTION
## Summary
- stop invoking the Make webhook when catalog links are clicked
- remove the unused category selection webhook helper
- enforce verification context on the catalog landing page and redirect unverified visitors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd67179e4483289e0c4dc46106fc43