### PR TITLE
Adjust verification handling for catalog access

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,10 +68,10 @@
     <li><a data-category="Сервісні умови та гарантія" data-url="https://dolota.ua/product/" href="#" rel="noopener" target="_blank">Сервісні умови та гарантія <span class="badge">PDF</span></a></li>
   </ul>
 <div class="cta-row">
-<div class="cta"><a data-base="https://t.me/dolota_pr_bot" href="https://t.me/dolota_pr_bot" id="tgCta" rel="noopener" target="_blank">
+      <div class="cta"><a data-base="https://t.me/dolota_pr_bot" data-skip-verification="true" href="https://t.me/dolota_pr_bot" id="tgCta" rel="noopener" target="_blank">
 <svg aria-hidden="true" height="18" style="display:inline-block;vertical-align:-3px;margin-right:8px;fill:currentColor;" viewbox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg"><path d="M22.99 3.2c.26-.95-.73-1.77-1.62-1.37L2.7 9.87c-1.02.45-.94 1.94.12 2.27l4.9 1.58 1.94 6.2c.29.93 1.49 1.1 2.05.29l2.78-3.97 5.06 3.72c.86.63 2.1.16 2.34-.87L22.99 3.2zM8.46 12.7l9.86-6.08c.15-.09.3.11.17.23l-8.05 7.52c-.15.14-.25.33-.29.54l-.39 2.33c-.03.2-.31.22-.36.02l-1.09-4.3c-.06-.24.04-.49.25-.62z"></path></svg>
             Уточнити ціну</a></div>
-      <div class="contact-alt"><div class="contact-box"><strong>Немає Telegram?</strong><br/>Зателефонуйте нам: <a class="call-btn" href="tel:+380933332212" id="callCta">Зателефонувати нам</a>
+      <div class="contact-alt"><div class="contact-box"><strong>Немає Telegram?</strong><br/>Зателефонуйте нам: <a class="call-btn" data-skip-verification="true" href="tel:+380933332212" id="callCta">Зателефонувати нам</a>
         <p class="contact-phone" data-copy-phone="+380933332212" role="button" tabindex="0">+380933332212</p>
       </div></div>
 </div>

--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -353,6 +353,7 @@ async function init() {
 
   hideLoader();
   showSendCodeButton();
+  toggleCodeSection(true);
 
   if (!remoteResult.error) {
     if (context.catalogName) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -424,6 +424,9 @@ function promptForMissingContext() {
 function handleCatalogClick(ev) {
   const a = ev.target.closest('#catalogs a[data-category], #catalogs a[href], #catalogs a[data-url]');
   if (!a) return;
+  if (a.hasAttribute('data-skip-verification')) {
+    return;
+  }
   ev.preventDefault();
   const rawHref = a.getAttribute('href');
   const dataUrl = a.getAttribute('data-url') || a.dataset.url;


### PR DESCRIPTION
## Summary
- allow the Telegram and phone call CTAs to bypass the catalog phone verification gate
- show the manual confirmation form when the remote verification status cannot confirm the phone

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd8428384083288d2ae0749743d37d