### PR TITLE
Prevent iOS from auto-styling contact phone numbers and zooming inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>
+<meta content="telephone=no" name="format-detection"/>
 <title>DOLOTA | Реєстрація контакту</title>
 <meta content="Реєстрація контакту відвідувача стенду DOLOTA для надання доступу до каталогів." name="description"/>
 <link href="styles/main.css" rel="stylesheet"/>
@@ -26,7 +27,7 @@
 <div class="grid">
 <div>
 <label class="req" for="firstName">Ім’я</label>
-<input autocomplete="given-name" autofocus="" id="firstName" name="firstName" placeholder="Тарас" required=""/>
+<input autocomplete="given-name" id="firstName" name="firstName" placeholder="Тарас" required=""/>
 </div>
 <div>
 <label class="req" for="lastName">Прізвище</label>

--- a/pages/catalogs.html
+++ b/pages/catalogs.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="format-detection" content="telephone=no" />
   <title>DOLOTA | Каталоги та матеріали</title>
   <meta name="description" content="Перегляд каталогів та матеріалів DOLOTA після підтвердження номера телефону." />
   <link rel="stylesheet" href="../styles/main.css" />

--- a/pages/confirm-phone.html
+++ b/pages/confirm-phone.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="format-detection" content="telephone=no" />
   <title>DOLOTA | Підтвердження номера</title>
   <meta name="description" content="Підтвердження номера телефону для відкриття каталогів та матеріалів DOLOTA." />
   <link rel="stylesheet" href="../styles/confirm-phone.css" />

--- a/styles/main.css
+++ b/styles/main.css
@@ -144,6 +144,8 @@ input {
   border: 1px solid var(--input-border);
   background: var(--input);
   color: var(--text);
+  font-size: 16px;
+  line-height: 1.4;
   outline: none;
 }
 
@@ -161,6 +163,8 @@ input {
   border-radius: 0;
   flex: 1;
   padding-left: 12px;
+  font-size: 16px;
+  line-height: 1.4;
 }
 
 .phone-prefix {
@@ -186,13 +190,25 @@ input {
   cursor: pointer;
   display: inline-block;
   transition: transform 0.12s ease, opacity 0.12s ease;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  line-height: inherit;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .contact-phone:hover,
-.contact-phone:focus {
+.contact-phone:focus-visible {
   opacity: 0.85;
   transform: translateY(-1px);
-  outline: none;
+}
+
+.contact-phone:focus-visible {
+  outline: 2px solid var(--brand-yellow);
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 .contact-phone.copied::after {


### PR DESCRIPTION
## Summary
- disable Safari telephone auto-detection on all pages so contact numbers keep custom styling
- reset the `.contact-phone` styles to remove native button appearance and provide a clear focus outline
- keep iOS from auto-zooming the registration form by removing the autofocus attribute and enforcing a 16px input font size

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68de5e37db6c83289873d0e833992c49