### PR TITLE
Fix confirmation code section visibility

### DIFF
--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -314,6 +314,8 @@ async function checkRemoteVerification(ctx, displayValue) {
 }
 
 async function init() {
+  toggleCodeSection(false);
+  toggleResendLink(false);
   context = parseContext();
   if (!context) {
     context = consumePersistedContext();
@@ -353,7 +355,8 @@ async function init() {
 
   hideLoader();
   showSendCodeButton();
-  toggleCodeSection(true);
+  toggleCodeSection(false);
+  toggleResendLink(false);
 
   if (!remoteResult.error) {
     if (context.catalogName) {


### PR DESCRIPTION
## Summary
- ensure the confirmation code section stays hidden on page load and after status checks
- hide the resend link until a verification code is successfully sent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de6543a5dc8328a23bc743f0739f3e