### PR TITLE
Fix confirm phone script initialization error

### DIFF
--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -22,15 +22,6 @@ const RESEND_DEFAULT_TEXT = resendCodeLink
   ? resendCodeLink.textContent.trim()
   : 'Надіслати код повторно';
 
-const resendCountdownText = document.getElementById('resendCountdown');
-
-const RESEND_DELAY_SECONDS = 40;
-let resendCountdownTimer = null;
-let resendCountdownExpiresAt = null;
-const RESEND_DEFAULT_TEXT = resendCodeLink
-  ? resendCodeLink.textContent.trim()
-  : 'Надіслати код повторно';
-
 const statusEl = document.getElementById('confirmStatus');
 
 let context = null;


### PR DESCRIPTION
## Summary
- remove duplicated resend countdown variable declarations in `confirm-phone.js`
- restore execution of the confirmation script so the submitted phone number is displayed again

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e7b8dbf39083288dbee4ca951af4d6