### PR TITLE
Defer confirmation code entry until verification request

### DIFF
--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -22,15 +22,6 @@ const RESEND_DEFAULT_TEXT = resendCodeLink
   ? resendCodeLink.textContent.trim()
   : 'Надіслати код повторно';
 
-const resendCountdownText = document.getElementById('resendCountdown');
-
-const RESEND_DELAY_SECONDS = 40;
-let resendCountdownTimer = null;
-let resendCountdownExpiresAt = null;
-const RESEND_DEFAULT_TEXT = resendCodeLink
-  ? resendCodeLink.textContent.trim()
-  : 'Надіслати код повторно';
-
 const statusEl = document.getElementById('confirmStatus');
 
 let context = null;
@@ -331,8 +322,12 @@ async function sendVerificationCode({ resend = false, displayValue }) {
     }
   } catch (err) {
     setStatus('Не вдалося надіслати код. Спробуйте ще раз.', 'err');
-    if (!resend && sendCodeBtn) {
-      showSendCodeButton();
+    if (!resend) {
+      if (sendCodeBtn) {
+        showSendCodeButton();
+      }
+      toggleCodeSection(false);
+      toggleResendLink(false);
     }
     if (resend) {
       stopResendCountdown();
@@ -460,8 +455,6 @@ async function init() {
 
   hideLoader();
   showSendCodeButton();
-  toggleCodeSection(true);
-  toggleResendLink(true);
 
   if (!remoteResult.error) {
     if (context.catalogName) {
@@ -470,6 +463,9 @@ async function init() {
       setStatus('Введіть код, який ми надішлемо на вказаний номер телефону.', '');
     }
   }
+
+  toggleCodeSection(false);
+  toggleResendLink(false);
 
   if (codeInput) {
     codeInput.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- keep the SMS code input and resend controls hidden until the user requests a verification code
- reset the interface if sending the initial code fails so the resend control stays hidden
- ensure the resend button only appears after a send request and remains disabled during the 40-second cooldown

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e7b8dbf39083288dbee4ca951af4d6