### PR TITLE
Update webhook URLs for lead capture flows

### DIFF
--- a/scripts/confirm-phone.js
+++ b/scripts/confirm-phone.js
@@ -1,4 +1,4 @@
-const WEBHOOK_URL = 'https://hook.eu2.make.com/15sdp8heqq62udgrfmfquv4go2n9cbvs';
+const WEBHOOK_URL = 'https://hook.eu2.make.com/q6frdvkglswb72umh7jbjercc7gd2eqv';
 
 const CONTEXT_KEY = 'dolota_catalog_context';
 const CONTEXT_PERSIST_KEY = 'dolota_catalog_context_persist';

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -7,7 +7,7 @@ function genLeadId() {
 }
 
 window.__leadId = null;
-const WEBHOOK_URL = "https://hook.eu2.make.com/1eugiujlu8s20qptl3cgj49bikwkcrqc";
+const WEBHOOK_URL = "https://hook.eu2.make.com/qkjm77ab8dwde3lfyq41iaadon8dzpd1";
 
 // === Елементи ===
 const form = document.getElementById('leadForm');


### PR DESCRIPTION
## Summary
- update the main lead form to post to the new Make.com webhook endpoint
- switch the phone confirmation page to use the refreshed verification webhook URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7d5122d00832888a36f58c2fc1611